### PR TITLE
Renames for BodyHTTPRequest; change source for XMLRPCRouter, XMLRPCError

### DIFF
--- a/asphalt/web/context.py
+++ b/asphalt/web/context.py
@@ -8,7 +8,7 @@ from typeguard import check_argument_types
 from asphalt.core.context import Context
 from asphalt.serialization.api import Serializer
 from asphalt.templating.api import TemplateRenderer
-from asphalt.web.request import BodyHTTPRequest
+from asphalt.web.request import HTTPRequest
 from asphalt.web.response import HTTPResponse
 from asphalt.web.utils import encode_header_value
 
@@ -20,7 +20,7 @@ class HTTPRequestContext(Context):
     :ivar WebRequest request: the HTTP request object
     """
 
-    def __init__(self, parent: Context, request: BodyHTTPRequest):
+    def __init__(self, parent: Context, request: HTTPRequest):
         super().__init__(parent)
         self.request = request
 
@@ -32,7 +32,7 @@ class HTTPRequestResponseContext(HTTPRequestContext):
     :ivar WebResponse response: the HTTP response object
     """
 
-    def __init__(self, parent: Context, request: BodyHTTPRequest):
+    def __init__(self, parent: Context, request: HTTPRequest):
         super().__init__(parent, request)
         self.response = HTTPResponse
 

--- a/asphalt/web/router.py
+++ b/asphalt/web/router.py
@@ -120,7 +120,7 @@ class URLDispatchRouter(Router):
     def resolve(self, path: str, method: str) -> Optional[AbstractEndpoint]:
         pass
 
-    # def resolve(self, request: BodyHTTPRequest, path: PurePath) -> Optional[WebEndpoint]:
+    # def resolve(self, request: HTTPRequest, path: PurePath) -> Optional[WebEndpoint]:
     #     assert check_argument_types()
     #     for endpoint in self.endpoints:
     #         match = endpoint.match(parts)

--- a/asphalt/web/rpc/xmlrpc/__init__.py
+++ b/asphalt/web/rpc/xmlrpc/__init__.py
@@ -1,1 +1,1 @@
-from .router import XMLRPCRouter, XMLRPCError
+from .endpoint import XMLRPCRouter, XMLRPCError

--- a/asphalt/web/rpc/xmlrpc/endpoint.py
+++ b/asphalt/web/rpc/xmlrpc/endpoint.py
@@ -11,7 +11,7 @@ from typeguard import check_argument_types
 
 from asphalt.web.context import HTTPRequestContext
 from asphalt.web.exceptions import HTTPError
-from asphalt.web.request import BodyHTTPRequest
+from asphalt.web.request import HTTPRequest
 from asphalt.web.rpc.base import BaseRPCRouter
 from asphalt.web.rpc.xmlrpc.serialization import serialize, deserialize
 
@@ -62,7 +62,7 @@ class XMLRPCRouter(BaseRPCRouter):
         return ('<?xml version="1.0"?>\n<methodResponse><fault>' + fault +
                 '</fault></methodResponse>')
 
-    async def begin_request(self, parent_ctx: Context, request: BodyHTTPRequest):
+    async def begin_request(self, parent_ctx: Context, request: HTTPRequest):
         # Check that the HTTP method was "POST"
         if request.method != 'POST':
             raise HTTPError(405, 'POST required for XML-RPC')

--- a/asphalt/web/servers/fastcgi.py
+++ b/asphalt/web/servers/fastcgi.py
@@ -99,7 +99,7 @@ class FastCGIProtocol(Protocol):
         secure = 'HTTPS' in params
         peername = params['REMOTE_ADDR']
         peercert = params.get('CLIENT_CERTIFICATE')
-        # request = BodyHTTPRequest(http_version, method, path, query_string, headers, secure,
+        # request = HTTPRequest(http_version, method, path, query_string, headers, secure,
         #                           peername, peercert=peercert)
         self.endpoint = self.router.resolve(path, method)
         retval = self.endpoint.begin_request(request, self)

--- a/asphalt/web/static.py
+++ b/asphalt/web/static.py
@@ -5,7 +5,7 @@ from asphalt.core.context import Context
 from asphalt.web.api import AbstractEndpoint, Router
 from typeguard import check_argument_types
 
-from asphalt.web.request import BodyHTTPRequest
+from asphalt.web.request import HTTPRequest
 
 
 class StaticFileEndpoint(AbstractEndpoint):
@@ -14,7 +14,7 @@ class StaticFileEndpoint(AbstractEndpoint):
     def __init__(self, path: Path):
         self.path = path
 
-    def begin_request(self, parent_ctx: Context, request: BodyHTTPRequest):
+    def begin_request(self, parent_ctx: Context, request: HTTPRequest):
         if request.method != 'GET':
             raise HTTPMethodNotAllowed(request.method, ['GET'])
 
@@ -26,7 +26,7 @@ class StaticFileRouter(Router):
         assert check_argument_types()
         self.basedir = Path(basedir)
 
-    def resolve(self, request: BodyHTTPRequest, path: PurePath) -> Optional[AbstractEndpoint]:
+    def resolve(self, request: HTTPRequest, path: PurePath) -> Optional[AbstractEndpoint]:
         final_path = cast(Path, self.basedir / path)
         return StaticFileEndpoint(final_path) if final_path.is_file() else None
 

--- a/asphalt/web/websocket.py
+++ b/asphalt/web/websocket.py
@@ -5,7 +5,7 @@ from wsproto.connection import WSConnection, ConnectionType
 from wsproto.events import ConnectionRequested, ConnectionClosed, DataReceived
 
 from asphalt.web.api import AbstractEndpoint
-from asphalt.web.request import BodyHTTPRequest
+from asphalt.web.request import HTTPRequest
 from asphalt.web.servers.base import BaseHTTPClientConnection
 
 
@@ -37,7 +37,7 @@ class WebSocketEndpoint(AbstractEndpoint):
         if bytes_to_send:
             self._client.write(bytes_to_send)
 
-    def begin_request(self, request: BodyHTTPRequest):
+    def begin_request(self, request: HTTPRequest):
         trailing_data = self._client.upgrade()
         self._ws.receive_bytes(trailing_data)
         self._process_ws_events()


### PR DESCRIPTION
In order to fix some tests, I made these changes: 

Remove `Body` in front of BodyHTTPRequest. 

change source of XMLRPCRouter, XMLRPCError to the endpoint module.
